### PR TITLE
feat: use anyhow for errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
 name = "aws_secretsmanager_agent"
 version = "2.0.0"
 dependencies = [
+ "anyhow",
  "aws-config",
  "aws-sdk-secretsmanager",
  "aws-sdk-sts",

--- a/aws_secretsmanager_agent/Cargo.toml
+++ b/aws_secretsmanager_agent/Cargo.toml
@@ -25,6 +25,7 @@ aws-config = "1"
 aws-sdk-secretsmanager = "1"
 aws-smithy-runtime-api = "1"
 aws-sdk-sts = "1"
+anyhow = "1"
 log = "0.4.29"
 log4rs = { version = "1.2.0", features = ["gzip"] }
 url = "2"

--- a/aws_secretsmanager_agent/src/cache_manager.rs
+++ b/aws_secretsmanager_agent/src/cache_manager.rs
@@ -1,3 +1,5 @@
+use anyhow::Result;
+
 use crate::error::HttpError;
 use crate::utils::err_response;
 use aws_sdk_secretsmanager::error::ProvideErrorMetadata;
@@ -28,7 +30,7 @@ use tests::init_client as asm_client;
 /// Used to cache and retrieve secrets.
 impl CacheManager {
     /// Create a new CacheManager. For simplicity I'm propagating the errors back up for now.
-    pub async fn new(cfg: &Config) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(cfg: &Config) -> Result<Self> {
         Ok(Self(SecretsManagerCachingClient::new(
             asm_client(cfg).await?,
             cfg.cache_size(),
@@ -231,9 +233,7 @@ pub mod tests {
     }
 
     // Used to replace the real client with the stub client.
-    pub async fn init_client(
-        _cfg: &Config,
-    ) -> Result<secretsmanager::Client, Box<dyn std::error::Error>> {
+    pub async fn init_client(_cfg: &Config) -> Result<secretsmanager::Client> {
         Ok(CLIENT.with_borrow(|v| v.clone()))
     }
 

--- a/aws_secretsmanager_agent/src/logging.rs
+++ b/aws_secretsmanager_agent/src/logging.rs
@@ -1,4 +1,5 @@
 use crate::config::LogLevel;
+use anyhow::Result;
 use log::{info, LevelFilter, SetLoggerError};
 use log4rs::append::console::ConsoleAppender;
 use log4rs::append::rolling_file::policy::compound::roll::fixed_window::FixedWindowRoller;
@@ -41,10 +42,7 @@ static STARTUP: Once = Once::new();
 ///
 /// * `Ok(())` - If no errors are encountered.
 /// * `Err(Error)` - For errors initializing the log.
-pub fn init_logger(
-    log_level: LogLevel,
-    log_to_file: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
+pub fn init_logger(log_level: LogLevel, log_to_file: bool) -> Result<()> {
     let (log_config, logger_type) = match log_to_file {
         true => {
             let file_appender = "FILE_APPENDER";
@@ -101,7 +99,7 @@ pub fn init_logger(
         }
     });
     if let Some(err) = res {
-        return Err(Box::new(err));
+        return Err(err.into());
     }
 
     info!(

--- a/aws_secretsmanager_agent/src/server.rs
+++ b/aws_secretsmanager_agent/src/server.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use bytes::Bytes;
 use http_body_util::Full;
 use hyper::server::conn::http1;
@@ -43,10 +44,7 @@ impl Server {
     ///
     /// * `Ok(Self)` - The server object.
     /// * `Box<dyn std::error::Error>>` - Retruned for errors initializing the agent
-    pub async fn new(
-        listener: TcpListener,
-        cfg: &Config,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
+    pub async fn new(listener: TcpListener, cfg: &Config) -> Result<Self> {
         Ok(Self {
             listener: Arc::new(listener),
             cache_mgr: Arc::new(CacheManager::new(cfg).await?),
@@ -67,7 +65,7 @@ impl Server {
     /// # Errors
     ///
     /// * `std::io::Error` - Error while accepting request.
-    pub async fn serve_request(&self) -> Result<(), Box<dyn std::error::Error>> {
+    pub async fn serve_request(&self) -> Result<()> {
         let (stream, _) = self.listener.accept().await?;
         stream.set_ttl(1)?; // Prohibit network hops
         let io = TokioIo::new(stream);


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Error handling in the agent crate relied on `Box<dyn std::error::Error>` everywhere, which is verbose, provides no error context chaining, and led to awkward patterns like `Err("string")?` for ad-hoc errors.

2. The `init()` function in main.rs manually matched on every `Result` and called a `err_exit` helper to print-and-die, instead of propagating errors naturally. This made the initialization flow harder to follow and required a `-> !` helper with separate production/test implementations.

### What is changing?

1. Added `anyhow` as a dependency of `aws_secretsmanager_agent`and replaced all `Box<dyn std::error::Error>` return types with `anyhow::Result` across `config.rs`, `utils.rs`, `logging.rs`, `cache_manager.rs`, `server.rs`, and `main.rs`.
2. Replaced `Err("string")?` patterns in `config.rs` with `bail!()`.
3. Refactored `init()` to return `Result<(Config, TcpListener)>` using `?`, `bail!()`, and `.with_context()` for error propagation — replacing 4 manual `match`/`unwrap_or_else` + `err_exit` blocks.
4. Removed the `err_exit` helper entirely.
5. Simplified `get_token()` in `utils.rs` by replacing an `if none` / `unwrap` pattern with `.ok_or()`.
6. No changes to `aws_secretsmanager_caching` — it's a library crate and correctly uses `thiserror` for typed errors.

### Related Links
- **Issue #, if available**:
N/A

---

## Testing

### How was this tested?

1. All 73 existing unit tests in aws_secretsmanager_agent pass
2. All 32 unit tests in aws_secretsmanager_caching pass (unchanged, verified no breakage)
3. Integ tests pass locally `./test-local.sh`
4. Clean cargo build with no warnings
5. Pre-existing clippy warnings only (none introduced)

### When testing locally, provide testing artifact(s):

1. cargo test --package aws_secretsmanager_agent — 73 passed, 0 failed
2. cargo test --package aws_secretsmanager_caching — 32 passed, 0 failed

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [x] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
