### PR TITLE
Consolidate provider crate versions via workspace inheritance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,12 @@
 [workspace]
 resolver = "2"
-
 members = ["aws_workload_credentials_provider", "aws_workload_credentials_provider_common", "aws_secretsmanager_provider", "aws_secretsmanager_caching", "aws_certificatemanager_provider", "integration-tests"]
+
+[workspace.package]
+version = "3.1.1"
+
+[workspace.dependencies]
+aws_workload_credentials_provider_common = { version = "3.1.1", path = "aws_workload_credentials_provider_common" }
+aws_secretsmanager_provider = { version = "3.1.1", path = "aws_secretsmanager_provider" }
+aws_certificatemanager_provider = { version = "3.1.1", path = "aws_certificatemanager_provider" }
+aws_secretsmanager_caching = { version = "2.1.0", path = "aws_secretsmanager_caching" }

--- a/aws_certificatemanager_provider/Cargo.toml
+++ b/aws_certificatemanager_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_certificatemanager_provider"
-version = "3.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS ACM certificate management for the AWS Workload Credentials Provider."
@@ -26,7 +26,7 @@ tokio-util = "0.7.18"
 # We are required to use the sha1 feature to decrypt the password protected private keys.
 pkcs8 = { version = "0.10", features = ["encryption", "pem", "sha1-insecure"] }
 pkcs5 = "0.7"
-aws_workload_credentials_provider_common = { version = "3.1.1", path = "../aws_workload_credentials_provider_common" }
+aws_workload_credentials_provider_common.workspace = true
 
 [dev-dependencies]
 aws-smithy-mocks = "0.1"

--- a/aws_secretsmanager_caching/release.toml
+++ b/aws_secretsmanager_caching/release.toml
@@ -1,0 +1,2 @@
+shared-version = false
+tag-name = "aws_secretsmanager_caching-v{{version}}"

--- a/aws_secretsmanager_provider/Cargo.toml
+++ b/aws_secretsmanager_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_secretsmanager_provider"
-version = "3.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "The AWS Secrets Manager Provider is a local HTTP service that you can install and use in your compute environments to read secrets from Secrets Manager and cache them in memory."
@@ -37,8 +37,8 @@ log = "0.4.29"
 log4rs = { version = "1.2.0", features = ["gzip"] }
 tokio-util = "0.7.18"
 url = "2"
-aws_secretsmanager_caching = { version = "2.1.0", path = "../aws_secretsmanager_caching" }
-aws_workload_credentials_provider_common = { version = "3.1.1", path = "../aws_workload_credentials_provider_common" }
+aws_secretsmanager_caching.workspace = true
+aws_workload_credentials_provider_common.workspace = true
 regex = "1"
 rand = "0.10"
 
@@ -46,7 +46,7 @@ rand = "0.10"
 [dev-dependencies]
 hyper = { version = "1", features = ["http1", "server", "client"] }
 aws-smithy-runtime = { version = "1", features = ["test-util"] }
-aws_secretsmanager_caching = { version = "2.1.0", path = "../aws_secretsmanager_caching", features = ["test-util"] }
+aws_secretsmanager_caching = { workspace = true, features = ["test-util"] }
 tokio = { version = "1", features = ["test-util", "rt-multi-thread", "net", "macros"] }
 http = "0.2.9"
 aws-smithy-types = "1"

--- a/aws_workload_credentials_provider/Cargo.toml
+++ b/aws_workload_credentials_provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_workload_credentials_provider"
-version = "3.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "AWS Workload Credentials Provider binary — unified entry point for ACM and Secrets Manager modes."
@@ -13,9 +13,9 @@ path = "src/main.rs"
 fips = ["aws_certificatemanager_provider/fips", "aws_secretsmanager_provider/fips"]
 
 [dependencies]
-aws_workload_credentials_provider_common = { version = "3.1.1", path = "../aws_workload_credentials_provider_common" }
-aws_certificatemanager_provider = { version = "3.1.1", path = "../aws_certificatemanager_provider" }
-aws_secretsmanager_provider = { version = "3.1.1", path = "../aws_secretsmanager_provider" }
+aws_workload_credentials_provider_common.workspace = true
+aws_certificatemanager_provider.workspace = true
+aws_secretsmanager_provider.workspace = true
 
 clap = { version = "4", features = ["derive"] }
 tokio-util = "0.7.18"

--- a/aws_workload_credentials_provider_common/Cargo.toml
+++ b/aws_workload_credentials_provider_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aws_workload_credentials_provider_common"
-version = "3.1.1"
+version.workspace = true
 edition = "2021"
 license = "Apache-2.0"
 description = "Common library for AWS Workload Credentials Provider configuration validation and shared utilities."

--- a/integration-tests/release.toml
+++ b/integration-tests/release.toml
@@ -1,0 +1,1 @@
+release = false

--- a/release.toml
+++ b/release.toml
@@ -1,0 +1,8 @@
+allow-branch = ["main"]
+shared-version = true
+consolidate-commits = true
+pre-release-commit-message = "chore: release {{version}}"
+tag-message = "chore: release {{version}}"
+tag-name = "v{{version}}"
+# Publishing is handled by the publish-crates.yml GitHub Actions workflow.
+publish = false


### PR DESCRIPTION
## Description

### Why is this change being made?

1. A version bump previously required editing 4 separate `Cargo.toml` files, increasing the risk of operator mistakes during a release (forgetting a file or version mismatch).
2. Even after consolidating to the root `Cargo.toml`, there are still 4 places to update in that file — someone could bump `workspace.package.version` but forget the `workspace.dependencies` entries.

### What is changing?

1. Added `[workspace.package]` with `version` to the root `Cargo.toml`
2. Added `[workspace.dependencies]` for internal crate cross-references
3. Updated `aws_workload_credentials_provider`, `aws_workload_credentials_provider_common`, `aws_secretsmanager_provider`, and `aws_certificatemanager_provider` to use `version.workspace = true`
4. Updated internal path dependencies to use `workspace = true` references
5. `aws_secretsmanager_caching` retains its own independent version
6. Added `cargo-release` configuration so that version bumping is a single atomic command:
   ```sh
   cargo release patch --execute   # or minor/major
   ```
   This bumps `workspace.package.version` AND all `workspace.dependencies` entries, commits, tags, and pushes — eliminating the version-skew risk entirely.
7. Publishing remains handled by the `publish-crates.yml` workflow (cargo-release has `publish = false`).

### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. `cargo release patch --workspace --exclude integration-tests --exclude aws_secretsmanager_caching` dry-run output:
   ```
   Upgrading workspace to version 3.1.2
   Upgrading aws_workload_credentials_provider_common from 3.1.1 to 3.1.2 (inherited from workspace)
    Updating workspace's dependency from 3.1.1 to 3.1.2
   Upgrading aws_certificatemanager_provider from 3.1.1 to 3.1.2 (inherited from workspace)
    Updating workspace's dependency from 3.1.1 to 3.1.2
   Upgrading aws_secretsmanager_provider from 3.1.1 to 3.1.2 (inherited from workspace)
    Updating workspace's dependency from 3.1.1 to 3.1.2
   Upgrading aws_workload_credentials_provider from 3.1.1 to 3.1.2 (inherited from workspace)
   Pushing consolidate-workspace-version, v3.1.2 to origin
   ```

### When testing locally, provide testing artifact(s):

1. Packaged `Cargo.toml` for `aws_workload_credentials_provider_common` confirms workspace inheritance is resolved to the correct version with no path deps in the published artifact
2. `cargo-release` dry-run shows atomic bump of all 4 version sites

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* Local rustc (1.93) is older than required (1.94.1) for AWS SDK deps — CI will validate
- [ ] Unit test coverage check is passing
  *If not, why:* No code logic changed; only Cargo.toml metadata and config
- [ ] Integration tests pass locally
  *If not, why:* Requires newer rustc; CI will validate
- [x] I have updated integration tests (if needed)
- [x] I have ensured no sensitive information is leaking
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [ ] I have updated README/documentation (if needed)
  *If not, why:* No user-facing behavior change
- [x] I have clearly called out breaking changes (if any)

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.