### PR TITLE
Fix env var substitution

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -89,4 +89,4 @@ jobs:
           BIN: aws-workload-credentials-provider${{ matrix.ext }}
         shell: bash
         run: |
-          aws s3 cp "target/${{ matrix.target }}/release/$BIN" "s3://$BUCKET/$KEY_PREFIX${{ github.run_id }}/${{ matrix.target }}/$BIN"
+          aws s3 cp "target/${{ matrix.target }}/release/$BIN" "s3://$BUCKET/${KEY_PREFIX}${{ github.run_id }}/${{ matrix.target }}/$BIN"


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The `${{ github.run_id}}` substitution happens first which breaks the $KEY_PREFIX env var subtitution


### What is changing?

1. Add braces around the env var name


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. Testing the workflow in GitHub Actions.

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
