### PR TITLE
ci: run integration tests on CodeBuild-hosted runners

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,8 +13,10 @@ env:
 
 jobs:
   integration-tests:
-    runs-on: ubuntu-latest
-    
+    # CodeBuild-hosted runner. AWS credentials come from the runner's own IAM role, so the workflow
+    # does not assume a role.
+    runs-on: codebuild-awcp-runner-${{ github.run_id }}-${{ github.run_attempt }}-linux-5.0-large
+
     # Run if:
     # 1. Manual trigger or push to main, OR
     # 2. PR with "safe-to-test" label
@@ -23,17 +25,19 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     
     permissions:
-      id-token: write
       contents: read
       pull-requests: write
 
     env:
+      AWS_REGION: us-west-2
       LABEL_NAME: safe-to-test
       REPO: ${{ github.event.pull_request.base.repo.full_name }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
     
     steps:
     - name: Harden Runner
+      # Self-hosted runners need a StepSecurity agent, which CodeBuild runners do not have.
+      if: runner.environment == 'github-hosted'
       uses: step-security/harden-runner@v2.19.4
       with:
         egress-policy: audit
@@ -60,13 +64,6 @@ jobs:
       with:
         toolchain: stable
         override: true
-    
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v6
-      with:
-        role-to-assume: ${{ secrets.ROLE_ARN }}
-        role-session-name: aws-workload-credentials-provider-ci-${{ github.run_id }}
-        aws-region: us-west-2
     
     - name: Build provider binary
       run: cargo build


### PR DESCRIPTION
Runs the integration tests on a CodeBuild-hosted GitHub Actions runner instead of a GitHub-hosted runner.

On a CodeBuild-hosted runner, AWS credentials come from the IAM role attached to the runner itself, so the workflow no
longer assumes a role through the GitHub OIDC provider and no longer needs `id-token: write`. Runners stay ephemeral —
one job per runner.

Changes:

- `runs-on` uses the CodeBuild label form, on `linux-5.0` (x86_64) compute.
- Dropped the `Configure AWS credentials` step and `id-token: write`. `AWS_REGION` is now set on the job.
- `harden-runner` runs only on GitHub-hosted runners; on self-hosted runners it needs a StepSecurity agent that
  CodeBuild runners do not have.

The `publish` job in `staging.yml` is unchanged and still assumes `STAGING_ROLE_ARN`, so `staging.yml` keeps
`id-token: write`. `staging.yml` calls this workflow, so its nightly run picks up the change too.

Merge this only once the `awcp-runner` CodeBuild project exists in the test account: `push` to `main` triggers this
workflow, and without the project the job waits for a runner that never registers. Contributors running these tests
from their own fork will not get a runner, since the project is scoped to this repository. The `safe-to-test` label
gate is unchanged.

Reference: https://docs.aws.amazon.com/codebuild/latest/userguide/action-runner.html
