### PR TITLE
feat: add a one-line bootstrap installer for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
 - [AWS Workload Credentials Provider](#aws-workload-credentials-provider)
   - [Secrets Manager capability](#secrets-manager-capability)
   - [Certificate Management capability](#certificate-management-capability)
+  - [Quick install](#quick-install)
   - [Step 1: Build the Workload Credentials Provider binary](#step-1-build-the-workload-credentials-provider-binary)
       - [\[ RPM-based systems \]](#-rpm-based-systems-)
       - [\[ Debian-based systems \]](#-debian-based-systems-)
@@ -69,6 +70,22 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
       - [Option 1: Using the test script](#option-1-using-the-test-script)
       - [Option 2: Manual execution](#option-2-manual-execution)
     - [Test Organization](#test-organization)
+
+## Quick install<a name="workload-credentials-provider-quick-install"></a>
+
+The bootstrap installer downloads a released binary and the matching configuration directory, then runs the install script for you\. Use it unless you need to build from source, in which case follow Step 1 and Step 2 instead\.
+
+```sh
+sudo AWCP_VERSION=3.1.1 /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh)" \
+  -- --config /path/to/config.toml
+```
+
+`AWCP_VERSION` is required and must name a released, tagged version\. The script downloads the binary for your architecture from the artifact host and the service units and install scripts from the `v$AWCP_VERSION` tag, then hands off to the `install` script described in [Step 2](#workload-credentials-provider-install)\. Options must go after the `--`; the script refuses to run if they don't, because the shell would otherwise consume the first one\. It also accepts `--dry-run`, which downloads everything and then stops without installing\.
+
+As with Step 2, add the user account that your application runs under to the `aws-wcp-token` group so it can read the SSRF token file\.
+
+------
 
 ## Step 1: Build the Workload Credentials Provider binary<a name="workload-credentials-provider-build"></a>
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
 The bootstrap installer downloads a released binary and the matching configuration directory, then runs the install script for you\. Use it unless you need to build from source, in which case follow Step 1 and Step 2 instead\.
 
 ```sh
-installer=$(mktemp) && curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
-  https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
+installer=$(mktemp) && trap 'rm -f "$installer"' EXIT &&
+  curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
+    https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
   sudo AWCP_VERSION=3.1.1 bash "$installer" --config /path/to/config.toml
-rm -f "$installer"
 ```
 
 `AWCP_VERSION` is required and must name a released, tagged version\. The script downloads the binary for your architecture from the artifact host and the service units and install scripts from the `v$AWCP_VERSION` tag, then hands off to the `install` script described in [Step 2](#workload-credentials-provider-install)\. It also accepts `--dry-run`, which downloads everything, keeps it, and prints where, without installing\.

--- a/README.md
+++ b/README.md
@@ -76,12 +76,15 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
 The bootstrap installer downloads a released binary and the matching configuration directory, then runs the install script for you\. Use it unless you need to build from source, in which case follow Step 1 and Step 2 instead\.
 
 ```sh
-sudo AWCP_VERSION=3.1.1 /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh)" \
-  -- --config /path/to/config.toml
+installer=$(mktemp) && curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
+  https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
+  sudo AWCP_VERSION=3.1.1 bash "$installer" --config /path/to/config.toml
+rm -f "$installer"
 ```
 
-`AWCP_VERSION` is required and must name a released, tagged version\. The script downloads the binary for your architecture from the artifact host and the service units and install scripts from the `v$AWCP_VERSION` tag, then hands off to the `install` script described in [Step 2](#workload-credentials-provider-install)\. Options must go after the `--`; the script refuses to run if they don't, because the shell would otherwise consume the first one\. It also accepts `--dry-run`, which downloads everything and then stops without installing\.
+`AWCP_VERSION` is required and must name a released, tagged version\. The script downloads the binary for your architecture from the artifact host and the service units and install scripts from the `v$AWCP_VERSION` tag, then hands off to the `install` script described in [Step 2](#workload-credentials-provider-install)\. It also accepts `--dry-run`, which downloads everything, keeps it, and prints where, without installing\.
+
+Download to a file rather than piping into a shell: `bash -c "$(curl …)"` exits 0 when the download fails, because the substitution is simply empty, so a failed install reads as a successful one\. If you do use that form, options must go after a `--`, since the shell would otherwise consume the first one as `$0`\.
 
 As with Step 2, add the user account that your application runs under to the `aws-wcp-token` group so it can read the SSRF token file\.
 

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,7 @@ main() {
     esac
 
     [ "$(id -u)" -eq 0 ] || die "must run as root"
-    [ "$(uname -s)" = Linux ] || die "unsupported OS: $(uname -s). On Windows, use install.ps1"
+    [ "$(uname -s)" = Linux ] || die "unsupported OS: $(uname -s). On Windows, follow the Windows quick install in the README"
 
     case "$(uname -m)" in
         x86_64 | amd64) target=x86_64-unknown-linux-gnu ;;
@@ -60,7 +60,7 @@ main() {
     esac
 
     # Commands this script uses itself, resolved the way it will call them.
-    for cmd in curl mktemp tar; do
+    for cmd in curl mktemp od tar; do
         command -v "$cmd" >/dev/null || die "required command not found: $cmd"
     done
 
@@ -69,8 +69,8 @@ main() {
     # doesn't pass here and go missing at use time. Checked up front, since a
     # host missing sha256sum installs cleanly and then serves 403s, and one
     # missing bash dies after the whole binary has been downloaded.
-    for cmd in bash chgrp chmod chown cut dd grep groupadd id install sha256sum \
-        sleep systemctl useradd; do
+    for cmd in bash cat chgrp chmod chown cut dd grep groupadd id install mkdir \
+        rm sha256sum sleep systemctl touch useradd; do
         PATH=/bin:/usr/bin:/sbin:/usr/sbin command -v "$cmd" >/dev/null ||
             die "required command not found on the install script's PATH: $cmd"
     done
@@ -98,22 +98,51 @@ main() {
     # Strip --dry-run and leave the rest in "$@" for the install script.
     # Rotating through "$@" keeps arguments containing spaces intact.
     dry_run=false
+    config_next=false
     remaining=$#
     while [ "$remaining" -gt 0 ]; do
         arg=$1
         shift
-        if [ "$arg" = --dry-run ]; then
+        if [ "$config_next" = true ]; then
+            config_next=false
+            # Made absolute here: the install script cds to its own directory
+            # before it copies the config, so a relative path would resolve
+            # against the staging directory instead of the caller's, and the
+            # copy would fail with users, units and the binary already on disk.
+            case $arg in
+                /*) ;;
+                *) arg="$PWD/$arg" ;;
+            esac
+            [ -f "$arg" ] || die "cannot find config file: $arg"
+            set -- "$@" "$arg"
+        elif [ "$arg" = --dry-run ]; then
             dry_run=true
         else
+            if [ "$arg" = --config ]; then
+                config_next=true
+            fi
             set -- "$@" "$arg"
         fi
         remaining=$((remaining - 1))
     done
 
-    # /var/tmp rather than /tmp, and TMPDIR deliberately ignored: the install
-    # script execs the binary from here for its pre-flight checks, and hardened
-    # hosts commonly mount /tmp noexec.
-    tmp=$(mktemp -d /var/tmp/awcp-install.XXXXXX)
+    # The install script runs setup-permissions.sh directly rather than through
+    # bash, so the staging filesystem has to allow exec. Hardened hosts mount
+    # /tmp noexec and often /var/tmp with it, so the choice is probed rather
+    # than assumed, and TMPDIR is ignored so it can't point somewhere noexec.
+    tmp=""
+    for base in /var/tmp /var/lib /opt; do
+        candidate=$(mktemp -d "$base/awcp-install.XXXXXX" 2> /dev/null) || continue
+        probe="$candidate/exec-probe"
+        if (printf '#!/bin/sh\n' > "$probe" && chmod 755 "$probe" && "$probe") 2> /dev/null; then
+            rm -f "$probe"
+            tmp=$candidate
+            break
+        fi
+        rm -rf "$candidate"
+    done
+    [ -n "$tmp" ] ||
+        die "no exec-capable staging directory: tried /var/tmp /var/lib /opt, all rejected exec"
     trap 'rm -rf "$tmp"' EXIT
     # A signal handler returns to the next command, so these have to exit
     # themselves or the script would carry on with its work directory deleted.
@@ -142,6 +171,13 @@ main() {
     source_dir="$configuration/../../target/release"
     mkdir -p "$source_dir"
     fetch "$BASE_URL/$version/$target/$BIN" "$source_dir/$BIN"
+    # A proxy or a misconfigured object can answer 200 with an HTML error page,
+    # which curl -f accepts. The magic number is not integrity checking, but it
+    # turns that into a clear failure here rather than an exec-format error after
+    # the users, units and binary are on disk.
+    magic=$(od -An -tx1 -N4 "$source_dir/$BIN" | tr -d ' \n')
+    [ "$magic" = 7f454c46 ] ||
+        die "$BASE_URL/$version/$target/$BIN is not an ELF binary; got magic $magic"
     chmod 755 "$source_dir/$BIN"
 
     if [ "$dry_run" = true ]; then

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,146 @@
+#!/bin/sh
+# Bootstrap installer for the AWS Workload Credentials Provider on Linux.
+#
+#   sudo AWCP_VERSION=3.1.1 /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -fsSL \
+#     https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh)" \
+#     -- --config /path/to/config.toml
+#
+# Downloads the release binary and the matching configuration directory, then
+# runs the install script from it. Options other than --dry-run are passed
+# through to that script.
+#
+# The version is explicit: the binary comes from the artifact host and the
+# service units and install scripts come from the repository at tag v$AWCP_VERSION,
+# so both halves are pinned to the same release.
+#
+# Environment:
+#   AWCP_VERSION   Version to install, in the pattern x.y.z. Required.
+#   AWCP_BASE_URL  Artifact host.
+#   AWCP_REPO_URL  Repository the configuration directory is fetched from.
+#
+# Everything runs from main, called on the last line, so a download truncated
+# mid-transfer can't execute a partial install.
+
+set -eu
+
+BASE_URL="${AWCP_BASE_URL:-https://artifacts.awcp.global.on.aws}"
+REPO_URL="${AWCP_REPO_URL:-https://github.com/aws/aws-workload-credentials-provider}"
+BIN=aws-workload-credentials-provider
+
+die() {
+    echo "install.sh: $*" >&2
+    exit 1
+}
+
+fetch() {
+    curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$2" -- "$1" ||
+        die "download failed: $1"
+}
+
+main() {
+    # `bash -c <script> [name [args...]]` assigns the first word after the
+    # script to $0, so an operator who omits the `--` loses their first option
+    # silently. Refuse rather than install something they didn't ask for.
+    case "$0" in
+        --) ;;
+        -*) die "unexpected \$0 '$0': put -- before the options, as in 'sh -s -- --dry-run'" ;;
+    esac
+
+    [ "$(id -u)" -eq 0 ] || die "must run as root"
+    [ "$(uname -s)" = Linux ] || die "unsupported OS: $(uname -s). On Windows, use install.ps1"
+
+    case "$(uname -m)" in
+        x86_64 | amd64) target=x86_64-unknown-linux-gnu ;;
+        aarch64 | arm64) target=aarch64-unknown-linux-gnu ;;
+        *) die "unsupported architecture: $(uname -m)" ;;
+    esac
+
+    # Commands used here and by the install script this hands off to, so a host
+    # missing one of them fails before anything is downloaded or created.
+    for cmd in chgrp chmod chown curl grep groupadd id install mktemp \
+        systemctl tar useradd; do
+        command -v "$cmd" >/dev/null || die "required command not found: $cmd"
+    done
+
+    version="${AWCP_VERSION:-}"
+    [ -n "$version" ] ||
+        die "set AWCP_VERSION to the version to install, as in 'sudo AWCP_VERSION=3.1.1 ...'"
+    echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
+        die "not a valid version: $version"
+
+    # `bash -c <script> -- <options>` consumes the -- as $0, but running the
+    # file directly leaves it as the first argument, so drop it here to make
+    # both invocations behave the same.
+    if [ "${1:-}" = "--" ]; then
+        shift
+    fi
+
+    # Strip --dry-run and leave the rest in "$@" for the install script.
+    # Rotating through "$@" keeps arguments containing spaces intact.
+    dry_run=false
+    remaining=$#
+    while [ "$remaining" -gt 0 ]; do
+        arg=$1
+        shift
+        if [ "$arg" = --dry-run ]; then
+            dry_run=true
+        else
+            set -- "$@" "$arg"
+        fi
+        remaining=$((remaining - 1))
+    done
+
+    # /var/tmp rather than /tmp, and TMPDIR deliberately ignored: the install
+    # script execs the binary from here for its pre-flight checks, and hardened
+    # hosts commonly mount /tmp noexec.
+    tmp=$(mktemp -d /var/tmp/awcp-install.XXXXXX)
+    trap 'rm -rf "$tmp"' EXIT
+    # A signal handler returns to the next command, so these have to exit
+    # themselves or the script would carry on with its work directory deleted.
+    trap 'rm -rf "$tmp"; exit 130' HUP INT TERM
+    mkdir "$tmp/repo"
+
+    echo "Installing $BIN $version ($target)"
+
+    # The tag is what ties the units and scripts to the release. A missing tag
+    # means the version was published without being tagged. Fetched before the
+    # binary so a bad version fails on 200 KB rather than tens of megabytes.
+    archive="$REPO_URL/archive/refs/tags/v$version.tar.gz"
+    curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$tmp/repo.tar.gz" -- "$archive" ||
+        die "cannot fetch $archive; is v$version tagged?"
+    tar --no-same-owner -xzf "$tmp/repo.tar.gz" -C "$tmp/repo"
+    # GitHub names the archive's top directory after the repository and tag, so
+    # a glob finds it without depending on find(1) being installed.
+    configuration=""
+    for candidate in "$tmp"/repo/*/aws_workload_credentials_provider_common/configuration; do
+        if [ -f "$candidate/install" ]; then
+            configuration=$candidate
+            break
+        fi
+    done
+    [ -n "$configuration" ] || die "no configuration directory in $archive"
+
+    # The install script installs the binary itself, from ../../target/release
+    # relative to its own location, which is where a source build leaves it. So
+    # download straight there and let it do the rest: it owns the destination,
+    # its ownership, and the order things are created in. Downloaded after the
+    # archive is extracted, so no archive member can stand in for the binary.
+    source_dir="$configuration/../../target/release"
+    mkdir -p "$source_dir"
+    fetch "$BASE_URL/$version/$target/$BIN" "$source_dir/$BIN"
+    chmod 755 "$source_dir/$BIN"
+
+    if [ "$dry_run" = true ]; then
+        echo "Downloaded $BIN $version and the v$version configuration. Install skipped (--dry-run)."
+        return 0
+    fi
+
+    # Run through bash rather than exec'ing the file, so a noexec staging
+    # directory doesn't block the install. -e is explicit because `bash <file>`
+    # drops the shebang's flags, and releases up to 3.1.1 take errexit from the
+    # shebang alone: without it their installer runs past a rejected config and
+    # reports success.
+    bash -e "$configuration/install" "$@"
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 # Bootstrap installer for the AWS Workload Credentials Provider on Linux.
 #
-#   installer=$(mktemp) && curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
-#     https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
+#   installer=$(mktemp) && trap 'rm -f "$installer"' EXIT &&
+#     curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
+#       https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
 #     sudo AWCP_VERSION=3.1.1 bash "$installer" --config /path/to/config.toml
 #
 # Downloaded to a file rather than piped into a shell, because `bash -c "$(curl
@@ -51,7 +52,7 @@ main() {
     esac
 
     [ "$(id -u)" -eq 0 ] || die "must run as root"
-    [ "$(uname -s)" = Linux ] || die "unsupported OS: $(uname -s). On Windows, follow the Windows quick install in the README"
+    [ "$(uname -s)" = Linux ] || die "unsupported OS: $(uname -s). This installer is Linux only"
 
     case "$(uname -m)" in
         x86_64 | amd64) target=x86_64-unknown-linux-gnu ;;

--- a/install.sh
+++ b/install.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 # Bootstrap installer for the AWS Workload Credentials Provider on Linux.
 #
-#   sudo AWCP_VERSION=3.1.1 /bin/bash -c "$(curl --proto '=https' --tlsv1.2 -fsSL \
-#     https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh)" \
-#     -- --config /path/to/config.toml
+#   installer=$(mktemp) && curl --proto '=https' --tlsv1.2 -fsSL -o "$installer" \
+#     https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.sh &&
+#     sudo AWCP_VERSION=3.1.1 bash "$installer" --config /path/to/config.toml
+#
+# Downloaded to a file rather than piped into a shell, because `bash -c "$(curl
+# ...)"` exits 0 when the download fails: the substitution is empty and nothing
+# runs. That form still works, with the options after a --.
 #
 # Downloads the release binary and the matching configuration directory, then
 # runs the install script from it. Options other than --dry-run are passed
@@ -55,18 +59,34 @@ main() {
         *) die "unsupported architecture: $(uname -m)" ;;
     esac
 
-    # Commands used here and by the install script this hands off to, so a host
-    # missing one of them fails before anything is downloaded or created.
-    for cmd in chgrp chmod chown curl grep groupadd id install mktemp \
-        systemctl tar useradd; do
+    # Commands this script uses itself, resolved the way it will call them.
+    for cmd in curl mktemp tar; do
         command -v "$cmd" >/dev/null || die "required command not found: $cmd"
+    done
+
+    # Commands the install script and the token unit need, resolved against the
+    # PATH those pin rather than this shell's, so a useradd in /usr/local/sbin
+    # doesn't pass here and go missing at use time. Checked up front, since a
+    # host missing sha256sum installs cleanly and then serves 403s, and one
+    # missing bash dies after the whole binary has been downloaded.
+    for cmd in bash chgrp chmod chown cut dd grep groupadd id install sha256sum \
+        sleep systemctl useradd; do
+        PATH=/bin:/usr/bin:/sbin:/usr/sbin command -v "$cmd" >/dev/null ||
+            die "required command not found on the install script's PATH: $cmd"
     done
 
     version="${AWCP_VERSION:-}"
     [ -n "$version" ] ||
         die "set AWCP_VERSION to the version to install, as in 'sudo AWCP_VERSION=3.1.1 ...'"
-    echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$' ||
-        die "not a valid version: $version"
+    # Pattern-matched rather than piped through grep: ^ and $ anchor each line,
+    # not the whole value, and sh builtins that expand \n would let a second
+    # line ride along behind a valid first one.
+    case "$version" in
+        *[!0-9.]* | *..* | .* | *.) die "not a valid version: $version" ;;
+        *.*.*.*) die "not a valid version: $version" ;;
+        *.*.*) ;;
+        *) die "not a valid version: $version" ;;
+    esac
 
     # `bash -c <script> -- <options>` consumes the -- as $0, but running the
     # file directly leaves it as the first argument, so drop it here to make
@@ -108,17 +128,11 @@ main() {
     archive="$REPO_URL/archive/refs/tags/v$version.tar.gz"
     curl --proto '=https' --tlsv1.2 -fsSL --retry 3 -o "$tmp/repo.tar.gz" -- "$archive" ||
         die "cannot fetch $archive; is v$version tagged?"
-    tar --no-same-owner -xzf "$tmp/repo.tar.gz" -C "$tmp/repo"
-    # GitHub names the archive's top directory after the repository and tag, so
-    # a glob finds it without depending on find(1) being installed.
-    configuration=""
-    for candidate in "$tmp"/repo/*/aws_workload_credentials_provider_common/configuration; do
-        if [ -f "$candidate/install" ]; then
-            configuration=$candidate
-            break
-        fi
-    done
-    [ -n "$configuration" ] || die "no configuration directory in $archive"
+    # --strip-components drops the top directory GitHub names after the
+    # repository and tag, so the paths below don't have to rediscover it.
+    tar --no-same-owner --strip-components=1 -xzf "$tmp/repo.tar.gz" -C "$tmp/repo"
+    configuration="$tmp/repo/aws_workload_credentials_provider_common/configuration"
+    [ -f "$configuration/install" ] || die "no install script in $archive"
 
     # The install script installs the binary itself, from ../../target/release
     # relative to its own location, which is where a source build leaves it. So
@@ -131,7 +145,11 @@ main() {
     chmod 755 "$source_dir/$BIN"
 
     if [ "$dry_run" = true ]; then
-        echo "Downloaded $BIN $version and the v$version configuration. Install skipped (--dry-run)."
+        # Kept, so the operator can read the units and check the binary before
+        # committing to an install. Theirs to remove afterwards.
+        trap - EXIT HUP INT TERM
+        echo "Downloaded $BIN $version and the v$version configuration to $tmp"
+        echo "Install skipped (--dry-run). Remove $tmp when you are done."
         return 0
     fi
 


### PR DESCRIPTION
## Description

A one-command installer for a published release on Linux. The Windows half is #277, stacked on this branch; fixes to `configuration/install` are #280, stacked on top of both.

**Stack**, bottom to top:
1. #271 Linux quick install (`install.sh`)
2. #277 Windows quick install (`install.ps1`)
3. #280 install script fixes (`configuration/`)

### Why is this change being made?

Installing a release means cloning, installing Rust, building, and running `configuration/install` by hand.

### What is changing?

- **`install.sh`** at the repo root. It downloads a release and hands off to the existing install script; no install logic is duplicated.
- **The version is explicit.** `AWCP_VERSION` is required. The binary comes from the artifact host and the units and install scripts from the `v<version>` tag, so both halves are one release and the bucket stays binaries-only.
- README gains a Quick install section.

The install script is invoked as `bash -e`, because releases up to v3.1.1 take errexit from the shebang and `bash <file>` drops it.

Worth knowing:

- Linux artifacts are unsigned, so TLS is the only protection on the download. AWS Signer has no ELF platform; a detached signature would fix that separately.
- `install.sh` itself comes from `HEAD`; everything it installs is pinned to `v$AWCP_VERSION`.
- The installer needs the `v<version>` tag. No workflow creates one, so artifacts can ship before the tag exists. Worth closing in `validate-version`.

### Related Links
- **Issue #, if available**: n/a
- Windows half: #277. Install script fixes: #280. Related: #273, #274, #275.

---

## Testing

### How was this tested?

The documented one-liner, run into Amazon Linux 2023 systemd containers on a dev box against the live artifact host and live Secrets Manager, installing v3.1.1 with v3.1.1's own configuration.

### When testing locally, provide testing artifact(s):

| area | result |
| --- | --- |
| install | exits 0; binary `755` reporting `3.1.1`; config `440 root:awscreds`; token file `640 aws-wcp-token`, 64 hex chars; units enabled and active |
| SSRF gate | `/ping` returns `200 healthy`; missing and wrong tokens 403; `X-Forwarded-For` 400 |
| live secret fetch | 200, `ARN` and `VersionId` match `describe-secret` at `AWSCURRENT`; second fetch byte-identical; unknown id 400. Only length and digest recorded |
| arguments | `--config` with spaces, via `bash -c` and as a file, with and without `--`; bad `AWCP_VERSION` refused before any download; unknown version aborts with nothing created; `--dry-run` stops after downloading |
| errexit | v3.1.1's installer given a config the binary rejects prints `Installation complete.` and exits 0 under `bash`, and exits 1 with nothing enabled under `bash -e`, which is why the delegate is invoked with the flag |
| static | shellcheck clean |

Credentials came from `ada credentials print --format file` and were shredded afterwards.

### Not covered

- Amazon Linux 2023 only. Other distributions can be covered on request.
- Upgrade-in-place behavior, the staged `uninstall`, and the config pre-flight belong to #280 and are tested there.
- Open review items on this file: `--proto` does not constrain redirects, the version check is line-oriented, and the file is committed non-executable.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* no Rust changes; CI covers it. One macOS run failed in `tests::max_conn_test`, a pre-existing timing flake, and passed on re-run.
- [ ] Unit test coverage check is passing
  *If not, why:* no Rust changes.
- [ ] Integration tests pass locally
  *If not, why:* they cover resources this does not touch; the installer was exercised against live Secrets Manager instead.
- [ ] I have updated integration tests (if needed)
  *If not, why:* the installer path is not in that suite, and the harness needs privileged containers with systemd.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [x] I have updated README/documentation (if needed)
- [x] I have clearly called out breaking changes (if any)
  *`configuration/install` now restarts the two provider services rather than only starting them, so an in-place upgrade briefly interrupts them. The token service is left alone so the SSRF token survives.*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.




