### PR TITLE
Build Linux release binary on AL2

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -9,6 +9,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Linux binaries are built inside Amazon Linux 2 so they link against its
+  # glibc and stay runnable on AL2 and anything newer
+  AL2_IMAGE: public.ecr.aws/amazonlinux/amazonlinux:2
+  AL2_GLIBC_VERSION: "2.26"
 
 permissions:
   contents: read
@@ -64,8 +68,49 @@ jobs:
         with:
           fetch-depth: 1
 
+      # The runner's own glibc is far newer than AL2's, so Linux targets are
+      # built in an AL2 container instead. The container is driven with
+      # `docker run` rather than the job-level `container:` key because the
+      # Node.js used by JavaScript actions needs a newer glibc than AL2 has.
+      - name: Build release binary (Amazon Linux 2)
+        if: runner.os == 'Linux'
+        run: |
+          docker run --rm \
+            --volume "$PWD:/src" \
+            --workdir /src \
+            --env CARGO_TERM_COLOR \
+            --env TARGET=${{ matrix.target }} \
+            "$AL2_IMAGE" \
+            bash -euo pipefail -c '
+              # aws-lc-sys compiles C with cmake; AL2 ships cmake 3 as "cmake3"
+              yum install -y gcc gcc-c++ make cmake3 tar gzip
+              ln -s /usr/bin/cmake3 /usr/local/bin/cmake
+              curl --proto "=https" --tlsv1.2 -sSf https://sh.rustup.rs \
+                | sh -s -- -y --profile minimal --default-toolchain stable
+              source "$HOME/.cargo/env"
+              cargo build --release --target "$TARGET"
+            '
+          # The container builds as root, so hand the outputs back to the runner
+          sudo chown -R "$(id -u):$(id -g)" target
+
       - name: Build release binary
+        if: runner.os == 'Windows'
         run: cargo build --release --target ${{ matrix.target }}
+
+      # Guards against the build image drifting to a newer glibc than AL2's
+      - name: Verify glibc requirement
+        if: runner.os == 'Linux'
+        run: |
+          BIN=target/${{ matrix.target }}/release/aws-workload-credentials-provider
+          required=$(readelf --dyn-syms --wide "$BIN" \
+            | grep -oE 'GLIBC_[0-9]+\.[0-9]+' | sed 's/GLIBC_//' | sort -uV)
+          echo "Required glibc versions: $(echo $required)"
+          highest=$(echo "$required" | tail -n1)
+          if [[ "$(printf '%s\n%s\n' "$highest" "$AL2_GLIBC_VERSION" | sort -V | tail -n1)" \
+                != "$AL2_GLIBC_VERSION" ]]; then
+            echo "::error::$BIN requires glibc $highest, newer than Amazon Linux 2's $AL2_GLIBC_VERSION"
+            exit 1
+          fi
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The GitHub Actions runners have a version of glibc too recent which prevents running the compiled binary on distros with older glibc.


### What is changing?

1. Use AL2 as the build environment.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [ ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [x] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
