### PR TITLE
chore: require the release version to match the crate version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,30 @@ jobs:
   validate-version:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate version is semver
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Validate version is semver and matches the crate
         env:
           VERSION: ${{ inputs.version }}
         run: |
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::Version '$VERSION' is not valid semver (expected x.y.z)"
+            exit 1
+          fi
+          # The version becomes the S3 key prefix, so it has to be the version
+          # the binary actually reports.
+          crate_version=$(grep -m1 '^version = ' aws_workload_credentials_provider/Cargo.toml |
+            cut -d'"' -f2)
+          if [[ "$crate_version" != "$VERSION" ]]; then
+            echo "::error::Requested version '$VERSION' does not match aws_workload_credentials_provider/Cargo.toml ('$crate_version')"
             exit 1
           fi
   staging:


### PR DESCRIPTION
## Description

### Why is this change being made?

1. `inputs.version` becomes the S3 key prefix for every published artifact, but nothing checks it against the version compiled into the binary. Dispatching Release with `3.2.0` before bumping `Cargo.toml` publishes objects under `3.2.0/` whose `--version` reports `3.1.1`, and because they are written with `--if-none-match "*"` those keys cannot be corrected in place.

### What is changing?

1. `validate-version` also compares the requested version against `aws_workload_credentials_provider/Cargo.toml` and fails the run when they differ. It now checks out the repo, which it did not need before.

### Related Links
- **Issue #, if available**: n/a
- Split out of #271 at review request

---

## Testing

### How was this tested?

1. Ran the step's script locally against the current tree: `3.1.1` passes, `3.2.0` fails with `Requested version '3.2.0' does not match aws_workload_credentials_provider/Cargo.toml ('3.1.1')`, and `3.1` still fails the existing semver check.

### When testing locally, provide testing artifact(s):

1. See above; the workflow itself cannot be dispatched from a branch, because the OIDC trust policy pins `refs/heads/main`.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* workflow-only change; CI runs the build and unit tests.
- [ ] Unit test coverage check is passing
  *If not, why:* no code changes.
- [ ] Integration tests pass locally
  *If not, why:* not applicable to a workflow change.
- [ ] I have updated integration tests (if needed)
  *If not, why:* not applicable.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [ ] I have updated README/documentation (if needed)
  *If not, why:* no documented behavior changes.
- [x] I have clearly called out breaking changes (if any)
  *A release dispatched with a version that does not match `Cargo.toml` now fails instead of publishing mislabeled artifacts.*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
