### PR TITLE
chore: analyze every PowerShell script in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -73,6 +73,28 @@ jobs:
           files: ./codecov.json
           fail_ci_if_error: true
           use_oidc: true
+      - name: Analyze the PowerShell scripts
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -AcceptLicense
+          # ParseError is its own severity: filtering to Error and Warning alone
+          # would report a script PowerShell cannot even parse as clean.
+          #
+          # Excluded rules are style rather than defect: Write-Host is how these
+          # scripts talk to an operator's console; common.ps1 is dot-sourced, so
+          # its constants look unused; and the verb, noun, and ShouldProcess
+          # conventions would mean renaming existing helpers across every caller.
+          $findings = Invoke-ScriptAnalyzer -Path . -Recurse `
+            -Severity ParseError, Error, Warning `
+            -ExcludeRule PSAvoidUsingWriteHost, PSUseDeclaredVarsMoreThanAssignments, `
+              PSUseApprovedVerbs, PSUseSingularNouns, PSUseShouldProcessForStateChangingFunctions
+          if ($findings) {
+            $findings | Format-Table RuleName, Line, Message -AutoSize | Out-String | Write-Host
+            throw "PSScriptAnalyzer reported $($findings.Count) finding(s)"
+          }
+          Write-Host "PSScriptAnalyzer: clean"
+
       - name: Lint
         run: cargo fmt --all -- --check
       - name: Clippy

--- a/test-local.ps1
+++ b/test-local.ps1
@@ -13,7 +13,7 @@
     On Windows, the ACM refresh executor calls `schtasks /Run` against a
     scheduled task whose name is derived from the cert ARN. The tests
     register a per-cert scheduled task as the current user with Interactive
-    logon — no admin privileges required.
+    logon; no admin privileges required.
 #>
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Nothing lints the PowerShell in this repo. A syntax error in any `.ps1` reaches `main` and only fails when an operator runs it.
2. `test-local.ps1` contains a non-ASCII character with no BOM. Windows PowerShell 5.1 reads such a file as ANSI, so that line renders as mojibake on the hosts the script targets.

### What is changing?

1. `rust.yml` runs PSScriptAnalyzer over every `.ps1` on the Windows leg. `ParseError` is included deliberately: it is a severity of its own, so filtering to `Error, Warning` alone would report a script PowerShell cannot parse as clean.
2. Five convention rules are excluded, with the reason in a comment: `Write-Host` is how the installers report to an operator's console, `common.ps1` is dot-sourced so its constants look unused, and the verb, noun, and `ShouldProcess` conventions would require renaming existing helpers across every caller.
3. `test-local.ps1` loses its one non-ASCII character.

#271 adds the same step scoped to the two installer scripts, since those are what it changes. This widens it to the whole repo, so it should land after that one.

### Related Links
- **Issue #, if available**: n/a
- Split out of #271 at review request; depends on #271

---

## Testing

### How was this tested?

1. Ran PSScriptAnalyzer with these arguments in CI on this branch; the run reports `PSScriptAnalyzer: clean`.
2. An earlier unrestricted run over the same tree reported the findings this exclusion list covers: `PSUseDeclaredVarsMoreThanAssignments` on six `common.ps1` constants, `PSUseApprovedVerbs` and `PSUseSingularNouns` on four `common.ps1` helpers, `PSUseShouldProcessForStateChangingFunctions` on three, and `PSUseBOMForUnicodeEncodedFile` on `test-local.ps1` — the last of which this PR fixes rather than excludes.
3. All seven `.ps1` files parse clean with `[System.Management.Automation.Language.Parser]::ParseFile`.

### When testing locally, provide testing artifact(s):

1. See the Windows leg of this PR's CI run.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* no Rust changes; CI runs the build and unit tests.
- [ ] Unit test coverage check is passing
  *If not, why:* no code changes.
- [ ] Integration tests pass locally
  *If not, why:* not applicable to a CI and comment change.
- [ ] I have updated integration tests (if needed)
  *If not, why:* not applicable.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [ ] I have updated README/documentation (if needed)
  *If not, why:* no documented behavior changes.
- [x] I have clearly called out breaking changes (if any)
  *None. The new CI step can fail future PRs that add PowerShell findings, which is the point.*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
