### PR TITLE
feat: add a one-line bootstrap installer for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Remove-Item $installer
 
 Download to a file rather than running the response directly: `[scriptblock]::Create()` on an empty body produces a script block that does nothing and reports success, so a truncated or empty download would read as a completed install\.
 
+If your execution policy refuses to run the file, or refuses the unsigned install scripts it downloads, run it as `powershell.exe -ExecutionPolicy Bypass -File $installer -Version 3.1.1 -Config C:\path\to\config.toml`\. The script checks the policy before downloading anything and tells you the same thing\.
+
 The script verifies the Authenticode signature on the binary and passes `-Config` and `-NoStart` through to the `install.ps1` script described in [Step 2](#workload-credentials-provider-install)\. It also accepts the following parameters:
 - `-Version <x.y.z>` — Version to install; required, and may also be given as the `AWCP_VERSION` environment variable
 - `-Force` — \(Optional\) Stop running provider services before installing

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
   - [Secrets Manager capability](#secrets-manager-capability)
   - [Certificate Management capability](#certificate-management-capability)
   - [Quick install](#quick-install)
+      - [\[ Linux quick install \]](#-linux-quick-install-)
+      - [\[ Windows quick install \]](#-windows-quick-install-)
   - [Step 1: Build the Workload Credentials Provider binary](#step-1-build-the-workload-credentials-provider-binary)
       - [\[ RPM-based systems \]](#-rpm-based-systems-)
       - [\[ Debian-based systems \]](#-debian-based-systems-)
@@ -73,7 +75,10 @@ To download the source code, see [https://github\.com/aws/aws\-workload\-credent
 
 ## Quick install<a name="workload-credentials-provider-quick-install"></a>
 
-The bootstrap installer downloads a released binary and the matching configuration directory, then runs the install script for you\. Use it unless you need to build from source, in which case follow Step 1 and Step 2 instead\.
+The bootstrap installers download a released binary and the matching configuration directory, then run the install script for you\. Use them unless you need to build from source, in which case follow Step 1 and Step 2 instead\.
+
+------
+#### [ Linux quick install ]
 
 ```sh
 installer=$(mktemp) && trap 'rm -f "$installer"' EXIT &&
@@ -87,6 +92,20 @@ installer=$(mktemp) && trap 'rm -f "$installer"' EXIT &&
 Download to a file rather than piping into a shell: `bash -c "$(curl …)"` exits 0 when the download fails, because the substitution is simply empty, so a failed install reads as a successful one\. If you do use that form, options must go after a `--`, since the shell would otherwise consume the first one as `$0`\.
 
 As with Step 2, add the user account that your application runs under to the `aws-wcp-token` group so it can read the SSRF token file\.
+
+------
+#### [ Windows quick install ]
+
+Run the following in an Administrator PowerShell session\. If the download fails on an older host, run `[Net.ServicePointManager]::SecurityProtocol = 'Tls12'` first\.
+
+```powershell
+& ([scriptblock]::Create((Invoke-RestMethod https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1))) -Version 3.1.1 -Config C:\path\to\config.toml
+```
+
+The script verifies the Authenticode signature on the binary and passes `-Config` and `-NoStart` through to the `install.ps1` script described in [Step 2](#workload-credentials-provider-install)\. It also accepts the following parameters:
+- `-Version <x.y.z>` — Version to install; required, and may also be given as the `AWCP_VERSION` environment variable
+- `-Force` — \(Optional\) Stop running provider services before installing
+- `-DryRun` — \(Optional\) Download and verify, then stop without installing
 
 ------
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,13 @@ As with Step 2, add the user account that your application runs under to the `aw
 Run the following in an Administrator PowerShell session\. If the download fails on an older host, run `[Net.ServicePointManager]::SecurityProtocol = 'Tls12'` first\.
 
 ```powershell
-& ([scriptblock]::Create((Invoke-RestMethod https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1))) -Version 3.1.1 -Config C:\path\to\config.toml
+$installer = Join-Path $env:TEMP "awcp-install.ps1"
+Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1 -OutFile $installer
+& $installer -Version 3.1.1 -Config C:\path\to\config.toml
+Remove-Item $installer
 ```
+
+Download to a file rather than running the response directly: `[scriptblock]::Create()` on an empty body produces a script block that does nothing and reports success, so a truncated or empty download would read as a completed install\.
 
 The script verifies the Authenticode signature on the binary and passes `-Config` and `-NoStart` through to the `install.ps1` script described in [Step 2](#workload-credentials-provider-install)\. It also accepts the following parameters:
 - `-Version <x.y.z>` — Version to install; required, and may also be given as the `AWCP_VERSION` environment variable

--- a/install.ps1
+++ b/install.ps1
@@ -39,6 +39,10 @@
     success, so a failed download would read as a completed install.
 #>
 
+# CmdletBinding, so an unknown switch is an error rather than being collected
+# into $args: without it a mistyped -DryRun binds to nothing, $DryRun stays
+# false, and what the operator meant as a rehearsal is a real install.
+[CmdletBinding()]
 param(
     [string]$Version = $env:AWCP_VERSION,
     [string]$Config,

--- a/install.ps1
+++ b/install.ps1
@@ -68,6 +68,16 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
     throw "PowerShell 5.0 or newer is required; this session is $($PSVersionTable.PSVersion)."
 }
 
+# The tag ships install.ps1, common.ps1 and the seed-token script as unsigned
+# .ps1 files, and they are run from disk: the delegate through the call operator,
+# the seed script through powershell.exe -File. A policy that refuses those fails
+# the install after the binary and the archive have been downloaded, and after the
+# services have been registered, so it is checked before any of that happens.
+$policy = Get-ExecutionPolicy
+if ($policy -in @("Restricted", "AllSigned")) {
+    throw "PowerShell execution policy is $policy, which blocks the unsigned install scripts this downloads. Re-run as 'powershell.exe -ExecutionPolicy Bypass -File <script>', or set 'Set-ExecutionPolicy -Scope Process Bypass' first."
+}
+
 $current = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
 if (-not $current.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
     throw "This script must be run as Administrator."

--- a/install.ps1
+++ b/install.ps1
@@ -30,7 +30,13 @@
     Download and verify, then stop without installing.
 
 .EXAMPLE
-    & ([scriptblock]::Create((Invoke-RestMethod https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1))) -Version 3.1.1 -Config C:\path\to\config.toml
+    $installer = Join-Path $env:TEMP "awcp-install.ps1"
+    Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1 -OutFile $installer
+    & $installer -Version 3.1.1 -Config C:\path\to\config.toml
+
+    Downloaded to a file rather than run from the response, because
+    [scriptblock]::Create() on an empty body silently does nothing and reports
+    success, so a failed download would read as a completed install.
 #>
 
 param(
@@ -70,7 +76,9 @@ if (-not $current.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrato
 if (-not $Version) {
     throw "Pass -Version (or set AWCP_VERSION) to the version to install, as in -Version 3.1.1"
 }
-if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+# \z, not $: .NET's $ also matches before a trailing newline, so a version with
+# one on the end would pass and then be interpolated into the download URLs.
+if ($Version -notmatch '^\d+\.\d+\.\d+\z') {
     throw "Not a valid version: $Version"
 }
 
@@ -93,6 +101,7 @@ $tmp = New-Item -ItemType Directory -Path (Join-Path $env:TEMP ("awcp-install-" 
 $previousProtocol = [Net.ServicePointManager]::SecurityProtocol
 $stoppedServices = @()
 $installed = $false
+$keepStaging = $false
 $delegateRan = $false
 try {
     & icacls $tmp.FullName /inheritance:r /grant "*S-1-5-18:(OI)(CI)F" /grant "*S-1-5-32-544:(OI)(CI)F" /Q | Out-Null
@@ -154,7 +163,11 @@ try {
         Where-Object { $_.Status -ne "Stopped" })
 
     if ($DryRun) {
-        Write-Host "Downloaded $EXE $Version and the v$Version configuration. Install skipped (-DryRun)."
+        # Kept, so the operator can read the scripts and check the binary before
+        # committing to an install. Theirs to remove afterwards.
+        $keepStaging = $true
+        Write-Host "Downloaded $EXE $Version and the v$Version configuration to $($tmp.FullName)"
+        Write-Host "Install skipped (-DryRun). Remove $($tmp.FullName) when you are done."
         if ($running) {
             Write-Host "  Note: $($running.Name -join ', ') running; a real install needs -Force."
         }
@@ -246,5 +259,7 @@ try {
         }
     }
     [Net.ServicePointManager]::SecurityProtocol = $previousProtocol
-    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    if (-not $keepStaging) {
+        Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,250 @@
+<#
+.SYNOPSIS
+    Bootstrap installer for the AWS Workload Credentials Provider on Windows.
+
+.DESCRIPTION
+    Downloads the release binary and the matching configuration directory, then
+    runs install.ps1 from it.
+
+    The version is explicit: the binary comes from the artifact host and the
+    service units and install scripts come from the repository at tag v<Version>,
+    so both halves are pinned to the same release.
+
+    The binary's Authenticode signature is verified before anything is
+    installed. It covers the binary only: the service registration and install
+    scripts come from the tag archive over TLS, with no signature of their own.
+
+.PARAMETER Version
+    Version to install, in the pattern x.y.z. Defaults to $env:AWCP_VERSION.
+
+.PARAMETER Config
+    Bootstrap config passed through to install.ps1.
+
+.PARAMETER NoStart
+    Install and register services but don't start them.
+
+.PARAMETER Force
+    Stop running provider services before installing.
+
+.PARAMETER DryRun
+    Download and verify, then stop without installing.
+
+.EXAMPLE
+    & ([scriptblock]::Create((Invoke-RestMethod https://raw.githubusercontent.com/aws/aws-workload-credentials-provider/HEAD/install.ps1))) -Version 3.1.1 -Config C:\path\to\config.toml
+#>
+
+param(
+    [string]$Version = $env:AWCP_VERSION,
+    [string]$Config,
+    [switch]$NoStart,
+    [switch]$Force,
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = "Stop"
+# Invoke-WebRequest's progress bar costs an order of magnitude on Windows
+# PowerShell 5.1.
+$ProgressPreference = "SilentlyContinue"
+
+$BASE_URL = if ($env:AWCP_BASE_URL) { $env:AWCP_BASE_URL } else { "https://artifacts.awcp.global.on.aws" }
+$REPO_URL = if ($env:AWCP_REPO_URL) { $env:AWCP_REPO_URL } else { "https://github.com/aws/aws-workload-credentials-provider" }
+$TARGET = "x86_64-pc-windows-msvc"
+$EXE = "aws-workload-credentials-provider.exe"
+# Compared against the decoded CN rather than a substring of Subject: .NET
+# quotes any attribute value containing a comma, so a pattern written against
+# the unquoted form silently never matches.
+$SIGNER_CN = "Amazon Web Services, Inc."
+
+# Checked at runtime rather than with #Requires, which applies to scripts and is
+# ignored when this is run as a script block, as the documented one-liner does.
+# Expand-Archive needs 5.0; Windows Server 2012 R2 ships 4.0.
+if ($PSVersionTable.PSVersion.Major -lt 5) {
+    throw "PowerShell 5.0 or newer is required; this session is $($PSVersionTable.PSVersion)."
+}
+
+$current = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
+if (-not $current.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "This script must be run as Administrator."
+}
+
+if (-not $Version) {
+    throw "Pass -Version (or set AWCP_VERSION) to the version to install, as in -Version 3.1.1"
+}
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Not a valid version: $Version"
+}
+
+# PROCESSOR_ARCHITEW6432 is set only in a 32-bit process on a 64-bit OS. Refused
+# rather than translated: that same process gets a ProgramFiles pointing at the
+# x86 tree, and common.ps1 builds the install directory from it, so the install
+# would land in "Program Files (x86)" and the services would be registered there.
+if ($env:PROCESSOR_ARCHITEW6432) {
+    throw "Running under 32-bit PowerShell on a 64-bit OS, which would install into ${env:ProgramFiles}. Re-run with $env:SystemRoot\sysnative\WindowsPowerShell\v1.0\powershell.exe, or the 64-bit powershell.exe."
+}
+if ($env:PROCESSOR_ARCHITECTURE -ne "AMD64") {
+    throw "Unsupported architecture: $env:PROCESSOR_ARCHITECTURE. Only $TARGET is published."
+}
+
+# A random name, created without -Force, so a pre-created directory in a
+# world-writable TEMP (C:\Windows\Temp when running as SYSTEM) cannot be reused
+# with its own ACL while this script writes the binary it is about to trust.
+$tmp = New-Item -ItemType Directory -Path (Join-Path $env:TEMP ("awcp-install-" + [IO.Path]::GetRandomFileName()))
+
+$previousProtocol = [Net.ServicePointManager]::SecurityProtocol
+$stoppedServices = @()
+$installed = $false
+$delegateRan = $false
+try {
+    & icacls $tmp.FullName /inheritance:r /grant "*S-1-5-18:(OI)(CI)F" /grant "*S-1-5-32-544:(OI)(CI)F" /Q | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to restrict the ACL on $($tmp.FullName) (icacls exit $LASTEXITCODE)"
+    }
+
+    # The repository archive is extracted alongside, never into, the directory
+    # holding the verified binary, so an archive member can't replace it.
+    $binDir = New-Item -ItemType Directory -Path (Join-Path $tmp "bin")
+    $repoDir = New-Item -ItemType Directory -Path (Join-Path $tmp "repo")
+
+    # Windows PowerShell 5.1 defaults to protocols older than TLS 1.2 on
+    # unpatched hosts. Restored in the finally block so the caller's session
+    # keeps whatever it had.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    Write-Host "Installing $EXE $Version ($TARGET)"
+
+    $exePath = Join-Path $binDir $EXE
+    Invoke-WebRequest -UseBasicParsing "$BASE_URL/$Version/$TARGET/$EXE" -OutFile $exePath
+
+    $sig = Get-AuthenticodeSignature $exePath
+    if ($sig.Status -ne "Valid") {
+        throw "Authenticode signature for $EXE $Version is $($sig.Status)"
+    }
+    $signerCn = $sig.SignerCertificate.GetNameInfo([Security.Cryptography.X509Certificates.X509NameType]::SimpleName, $false)
+    if ($signerCn -ne $SIGNER_CN) {
+        throw "Unexpected signer for $EXE $Version : $signerCn"
+    }
+    Write-Host "  Signature valid: $($sig.SignerCertificate.Subject)"
+
+    # The tag is what ties the units and scripts to the release. A missing tag
+    # means the version was published without being tagged.
+    $archive = "$REPO_URL/archive/refs/tags/v$Version.zip"
+    $archivePath = Join-Path $tmp "repo.zip"
+    try {
+        Invoke-WebRequest -UseBasicParsing $archive -OutFile $archivePath
+    } catch {
+        throw "Cannot fetch $archive; is v$Version tagged? $($_.Exception.Message)"
+    }
+    Expand-Archive -Path $archivePath -DestinationPath $repoDir -Force
+
+    $configurationDir = Get-ChildItem -Path $repoDir -Recurse -Directory -Filter configuration |
+        Where-Object { $_.Parent.Name -eq "aws_workload_credentials_provider_common" } |
+        Select-Object -First 1
+    if (-not $configurationDir) {
+        throw "No configuration directory in $archive"
+    }
+    $installScript = Join-Path $configurationDir.FullName "install.ps1"
+    if (-not (Test-Path $installScript)) {
+        throw "No install.ps1 in $($configurationDir.FullName)"
+    }
+    # Service names, paths, and Stop-ProviderService come from the same tag, so
+    # this wrapper can't drift from the version it is installing.
+    . (Join-Path $configurationDir.FullName "common.ps1")
+
+    $running = @(Get-Service -Name $ASM_SERVICE, $ACM_SERVICE -ErrorAction SilentlyContinue |
+        Where-Object { $_.Status -ne "Stopped" })
+
+    if ($DryRun) {
+        Write-Host "Downloaded $EXE $Version and the v$Version configuration. Install skipped (-DryRun)."
+        if ($running) {
+            Write-Host "  Note: $($running.Name -join ', ') running; a real install needs -Force."
+        }
+        return
+    }
+
+    # The bundled installer refuses to touch a running provider, so stop the
+    # services here first, with consent, since it drops in-flight requests.
+    if ($running -and -not $Force) {
+        throw "Provider services are running: $($running.Name -join ', '). Re-run with -Force to stop them and upgrade."
+    }
+
+    foreach ($svc in $running) {
+        # Recorded before the attempt: Stop-ProviderService throws if the process
+        # outlives its 30 second grace period, by which point the service has
+        # already been told to stop, so the restore below still has to run it.
+        $stoppedServices += $svc.Name
+        # Waits for the process to exit, not just for the service control
+        # manager to report Stopped, so the binary is no longer locked.
+        Stop-ProviderService -Name $svc.Name | Out-Null
+        Write-Host "  Stopped $($svc.Name)"
+    }
+
+    $installArgs = @{}
+    if ($Config) { $installArgs.Config = $Config }
+    if ($NoStart) { $installArgs.NoStart = $true }
+
+    # install.ps1 looks for the binary at ..\..\target\release relative to
+    # itself, which is where a source build leaves it, so put the downloaded one
+    # there. Written after the archive is extracted, so no archive member can
+    # stand in for it.
+    $sourceDir = New-Item -ItemType Directory -Force -Path `
+        (Join-Path $configurationDir.FullName "..\..\target\release")
+    Copy-Item -Path $exePath -Destination (Join-Path $sourceDir $EXE) -Force
+
+    $global:LASTEXITCODE = 0
+    $delegateRan = $true
+    & $installScript @installArgs
+    # Not a verdict on its own. The delegate reports a rejected config by way of
+    # Confirm-Config's `exit 1`, but it also ends with unchecked `icacls` calls,
+    # and icacls exits nonzero over a single unresolvable principal, so a
+    # completed install can leave this set. What the install did is checked on
+    # disk below; this only sharpens the message.
+    $delegateExit = $LASTEXITCODE
+    $detail = if ($delegateExit -ne 0) { " (it exited $delegateExit)" } else { "" }
+
+    # The delegate also exits 0 when it decides not to touch a running provider,
+    # so the binary on disk has to be the one just verified.
+    $installedExe = Join-Path $BIN_DIR $PROVIDER_EXE
+    if (-not (Test-Path $installedExe)) {
+        throw "configuration\install.ps1 did not install $installedExe$detail"
+    }
+    if ((Get-FileHash $installedExe -Algorithm SHA256).Hash -ne (Get-FileHash $exePath -Algorithm SHA256).Hash) {
+        throw "$installedExe is not the $Version binary$detail; stop the services and re-run"
+    }
+    # A config rejected on a re-install of the version already present would
+    # leave the binary matching, so compare what was asked for with what landed.
+    if ($Config) {
+        $installedConfig = Join-Path $PROVIDER_DIR $CONFIG_FILE_NAME
+        if (-not (Test-Path $installedConfig) -or
+            (Get-FileHash $installedConfig -Algorithm SHA256).Hash -ne (Get-FileHash $Config -Algorithm SHA256).Hash) {
+            throw "$Config was not installed to $installedConfig$detail"
+        }
+    }
+    if ($delegateExit -ne 0) {
+        Write-Warning "configuration\install.ps1 exited $delegateExit but installed $Version; check its output above."
+    }
+    $installed = $true
+    Write-Host "Installed $EXE $Version"
+} finally {
+    # Services stopped for an install that then failed would otherwise stay
+    # down until reboot: they are registered delayed-auto, not on-demand.
+    #
+    # Starting them is not a rollback. Once the delegate is running it replaces
+    # the binary and re-registers the services early on, and truncates the SSRF
+    # token before seeding it, so what starts here may be the new binary against
+    # a half-configured host.
+    if (-not $installed) {
+        if ($delegateRan) {
+            Write-Warning "configuration\install.ps1 had already started, so this host may be partially installed: re-run to finish, or run $BIN_DIR\uninstall.ps1 to remove it."
+        }
+        foreach ($name in $stoppedServices) {
+            try {
+                Start-Service -Name $name
+                Write-Warning "Install failed; started $name again."
+            } catch {
+                Write-Warning "Install failed and $name could not be restarted: $($_.Exception.Message)"
+            }
+        }
+    }
+    [Net.ServicePointManager]::SecurityProtocol = $previousProtocol
+    Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Description

The Windows half of the one-command installer. **Base branch is `feat/one-line-installer`, so review #271 first**; this diff shows only the Windows part. Fixes to `configuration/install.ps1` and `uninstall.ps1` are #280, stacked on top of this.

**Stack**, bottom to top:
1. #271 Linux quick install (`install.sh`)
2. #277 Windows quick install (`install.ps1`)
3. #280 install script fixes (`configuration/`)

### Why is this change being made?

Installing a release on Windows means cloning, installing the Rust toolchain, building, and running `configuration/install.ps1` by hand.

### What is changing?

- **`install.ps1`** at the repo root downloads a release and hands off to `configuration/install.ps1`. No install logic is duplicated.
- README gains the Windows half of the Quick install section.

Same shape as Linux: `-Version` (or `AWCP_VERSION`) is required, the binary comes from the artifact host, and the units and install scripts come from the `v<version>` tag.

Windows-specific choices:

- **Integrity is Authenticode**, not a digest, because signing rewrites the file after the release workflow uploads it. The check requires `Status = Valid` and a signer CN of exactly `Amazon Web Services, Inc.`, read with `GetNameInfo`: the real subject renders the CN quoted, because its value contains commas, so a pattern matched against `Subject` never fires.
- **The delegate's exit code is not a verdict.** `configuration/install.ps1` exits 0 when it declines to touch a running provider, and its trailing unchecked `icacls` calls can leave `$LASTEXITCODE` nonzero after a good install. The installed binary's digest, and the installed config when `-Config` was passed, are checked on disk instead; the exit code only sharpens the error message.
- **Service handling** comes from the tag's `common.ps1`. `Stop-ProviderService` waits for the process to exit, so the binary is unlocked when the delegate copies over it. Services stopped for an install that then fails are started again in `finally`, since they are `delayed-auto`; that is not a rollback, and the warning says so.
- **Staging** uses a random directory created without `-Force` plus `icacls /inheritance:r`, so a pre-created directory in a world-writable `TEMP` cannot be reused with its own ACL. The archive is extracted beside, never into, the directory holding the verified binary.
- Refuses to run under WOW64, where `ProgramFiles` points at the x86 tree that `common.ps1` builds the install directory from. PowerShell 5.0 is required, checked at runtime rather than with `#Requires`, which a script block ignores.
- TLS 1.2 is set for the download and restored afterwards, and `$ProgressPreference` is silenced, worth an order of magnitude on `Invoke-WebRequest` under 5.1.

### Related Links
- **Issue #, if available**: n/a
- Stacked on #271. Install script fixes: #280.

---

## Testing

### How was this tested?

End to end on an EC2 Windows Server 2022 instance through SSM `AWS-RunPowerShellScript`, so it ran as SYSTEM with `TEMP` at `C:\Windows\TEMP`, the world-writable case the staging hardening targets. The binary was the live signed 3.1.1 object from the artifact host, the configuration came from the real `v3.1.1` tag, and the secret fetch used the instance role via IMDS, so no credentials were copied to the host.

### When testing locally, provide testing artifact(s):

| area | result |
| --- | --- |
| install | signature verified, tag archive fetched, handoff completed; binary under `C:\Program Files\AWS\WorkloadCredentialsProvider\bin` reporting `3.1.1`; installed exe signature `Valid`, signer CN `Amazon Web Services, Inc.` |
| services | both registered and running under Virtual Service Accounts; `StartName` exactly `NT SERVICE\AWSWorkloadCredentialsProvider-SecretsManager` and `...-ACM` |
| token | 64 hex chars, ACL exactly `BUILTIN\Administrators`, `NT AUTHORITY\SYSTEM` and the two service accounts; boot-time `AWSWorkloadCredentialsProvider-SeedToken` task registered |
| HTTP | `/ping` returns `200 healthy`; missing and wrong tokens 403; `X-Forwarded-For` 400 |
| live secret fetch | 200, `ARN` and `VersionId` match `describe-secret` at `AWSCURRENT`; second fetch byte-identical; unknown id 400. 54 bytes, `sha256=eb345885...`, matching the Linux run |
| signer check | verified on .NET against the real quoted subject plus `Amazon Web Services, Inc.Evil`, a quote-injected `Amazon Web Services, Inc.",X=1`, and `Evil Corp`, all rejected |
| post-delegate checks | driven against a fake delegate: a good install that exits 1 from a trailing `icacls` warns and completes; exiting 0 without installing, a stale binary, and a config that never landed each abort |
| static | parses clean; PSScriptAnalyzer reports nothing at Error or Warning; parameter binding through `[scriptblock]::Create` verified, including a `-Config` path with spaces |

The instance, its instance profile and its role were deleted after the run.

### Not covered

- The WOW64 refusal and the PowerShell version check have no coverage on a real Windows host.
- CI does not run here: `rust.yml` triggers on PRs targeting `main`, and this targets `feat/one-line-installer`. It will run once this retargets after #271 merges.
- `sc.exe` registers the services with an unquoted `binPath` containing a space (pre-existing, CWE-428). Exploiting it needs write access to `C:\`, administrator-only by default.

### Noticed while testing, not fixed here

AWCP's HTTP responses carry no `Content-Type`, so PowerShell returns `Byte[]` and `Invoke-WebRequest ... | ConvertFrom-Json` yields nothing: `/ping` reads back as `200 104 101 97 108 116 104 121` until decoded with `[Text.Encoding]::UTF8.GetString($r.Content)`. Worth a server-side fix; the README's Windows retrieval examples mislead as written.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* no Rust changes, and CI does not run on a PR targeting a non-`main` branch; it will once this retargets after #271 merges.
- [ ] Unit test coverage check is passing
  *If not, why:* no Rust changes.
- [ ] Integration tests pass locally
  *If not, why:* they cover resources this does not touch. The installer was exercised end to end on an EC2 Windows host against live Secrets Manager, as described above.
- [ ] I have updated integration tests (if needed)
  *If not, why:* the installer path is not in that suite, and exercising it needs a Windows host.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [x] I have updated README/documentation (if needed)
- [x] I have clearly called out breaking changes (if any)
  *None. This adds one new file and a README section.*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.



