### PR TITLE
one line change to README for integration tests section

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ Your AWS credentials must have the following permissions:
 
 The role chaining integration tests require two IAM roles in the same account:
 
-1. **`asm-role-chaining-role`** — Must be assumable by the test runner's identity and have `secretsmanager:GetSecretValue` and `secretsmanager:DescribeSecret` permissions.
+1. **`asm-role-chaining-role`** — Must be assumable by the test runner's identity and have `secretsmanager:GetSecretValue`, `secretsmanager:DescribeSecret`, and `secretsmanager:BatchGetSecretValue` permissions.
 
 2. **`provider-no-access-role`** — Must be assumable by the test runner's identity but have *no* Secrets Manager permissions. Used to verify access-denied behavior.
 


### PR DESCRIPTION
## Description

### Why is this change being made?

1. The readme was missing the `secretsmanager:BatchGetSecretValue` permission for the 'asm-role-chaining-role'


### What is changing?

1. Added `secretsmanager:BatchGetSecretValue` to the role's required permissions in the README's integration test setup section.


### Related Links
- **Issue #, if available**:

---

## Testing

### How was this tested?

1. 

### When testing locally, provide testing artifact(s):

1. 

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
  *If not, why:*
- [x] I have filled out the Description and Testing sections above
  *If not, why:*
- [x] Build and Unit tests are passing
  *If not, why:*
- [x] Unit test coverage check is passing
  *If not, why:*
- [x] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*n/a
- [x] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*n/a

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
