### PR TITLE
fix: harden the provider install scripts on Linux and Windows

### DIFF
--- a/aws_workload_credentials_provider_common/configuration/install
+++ b/aws_workload_credentials_provider_common/configuration/install
@@ -4,6 +4,10 @@
 # Installs SM provider (HTTP interface) and ACM provider (certificate management).
 #
 
+# Set here as well as on the shebang, which is dropped when the file is run as
+# `bash install`, so the behavior doesn't depend on how the caller invoked it.
+set -e
+
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
@@ -23,6 +27,10 @@ Options:
     --no-privileges      Skip Linux capabilities on ACM service
     --no-sudoers         Skip sudoers generation
     -h, --help           Show this help message
+
+Exit codes:
+    0                    Installed, and the services that are enabled are running
+    3                    Installed, but a service is not running
 EOF
     exit 0
 }
@@ -52,9 +60,14 @@ if [ "$(id -u)" -ne 0 ]; then
     exit 1
 fi
 
-if [ -n "${CONFIG_FILE}" ] && [ ! -f "${CONFIG_FILE}" ]; then
-    echo "Cannot find config file: ${CONFIG_FILE}" >&2
-    exit 1
+if [ -n "${CONFIG_FILE}" ]; then
+    if [ ! -f "${CONFIG_FILE}" ]; then
+        echo "Cannot find config file: ${CONFIG_FILE}" >&2
+        exit 1
+    fi
+    # Resolved before the cd below, so a relative path keeps meaning what the
+    # caller meant rather than resolving against the script directory.
+    CONFIG_FILE="$(cd "$(dirname "${CONFIG_FILE}")" && pwd)/$(basename "${CONFIG_FILE}")"
 fi
 
 #
@@ -73,18 +86,68 @@ if [ ! -f "${PROVIDER_SOURCE_DIR}/${PROVIDER_BIN}" ]; then
     exit 1
 fi
 
+# Checks that run before anything is created, so a binary that can't load here
+# or a config that gets rejected costs nothing but the check.
+#
+# Both need to exec the source binary, which isn't always possible: release
+# artifacts arrive mode 644 (fixed by `install -m 755` below) and a staging
+# directory can be on a noexec mount. A trivial script in that directory tells
+# a directory that refuses every exec apart from a binary that won't run on this
+# host, which the exec status alone can't: noexec, a wrong-architecture ELF and a
+# missing loader all exit 126. A read-only directory can't be probed either, so
+# the whole attempt is one condition.
+SOURCE_BIN="${PROVIDER_SOURCE_DIR}/${PROVIDER_BIN}"
+PROBE="${PROVIDER_SOURCE_DIR}/.exec-probe.$$"
+SOURCE_DIR_EXEC=false
+if (printf '#!/bin/sh\n' > "${PROBE}" && chmod 755 "${PROBE}" && "${PROBE}") 2> /dev/null; then
+    SOURCE_DIR_EXEC=true
+fi
+rm -f "${PROBE}"
+
+CAN_EXEC_SOURCE=false
+if [ "${SOURCE_DIR_EXEC}" = false ]; then
+    echo "Skipping pre-flight checks: cannot exec from ${PROVIDER_SOURCE_DIR}" >&2
+elif [ ! -x "${SOURCE_BIN}" ]; then
+    echo "Skipping pre-flight checks: ${SOURCE_BIN} is not executable" >&2
+elif "${SOURCE_BIN}" --version > /dev/null 2>&1; then
+    CAN_EXEC_SOURCE=true
+else
+    echo "Aborting: ${SOURCE_BIN} does not run on this host" >&2
+    "${SOURCE_BIN}" --version >&2 || true
+    exit 1
+fi
+
+CHECK_CONFIG="${CONFIG_FILE:-${CONFIG_DIR}/config.toml}"
+if [ "${CAN_EXEC_SOURCE}" = true ] && [ -f "${CHECK_CONFIG}" ]; then
+    # setup-config-based-permissions validates the whole config before it
+    # generates anything, and --no-sudoers keeps it from writing a sudoers file
+    # that would reference the pre-install config path. For an ACM-enabled
+    # config it does write the systemd drop-in, which the run below rewrites
+    # from the installed config, so a rejection here can leave that one file
+    # behind and nothing else.
+    if ! "${SOURCE_BIN}" setup-config-based-permissions \
+        --config "${CHECK_CONFIG}" --no-sudoers; then
+        echo "Aborting: ${CHECK_CONFIG} was rejected; no services were installed" >&2
+        exit 1
+    fi
+fi
+
 #
 # User, group, and directory permissions
 #
 
-"${SCRIPT_DIR}/setup-permissions.sh"
+bash "${SCRIPT_DIR}/setup-permissions.sh"
 
 #
 # File installation
 #
 
-install -D -T -m 755 "${PROVIDER_SOURCE_DIR}/${PROVIDER_BIN}" "${PROVIDER_DIR}/bin/${PROVIDER_BIN}"
+install -D -T -m 755 "${SOURCE_BIN}" "${PROVIDER_DIR}/bin/${PROVIDER_BIN}"
 install -D -T -m 755 "${TOKEN_SCRIPT}" "${PROVIDER_DIR}/bin/${TOKEN_SCRIPT}"
+# Staged so the host can be cleaned up later: a bootstrap install deletes the
+# downloaded bundle, which used to be the only copy of these.
+install -D -T -m 750 "${SCRIPT_DIR}/uninstall" "${PROVIDER_DIR}/bin/uninstall"
+install -D -T -m 640 "${SCRIPT_DIR}/common.sh" "${PROVIDER_DIR}/bin/common.sh"
 
 #
 # Service installation
@@ -111,7 +174,20 @@ fi
 mkdir -p "${CONFIG_DIR}"
 chmod 755 "${CONFIG_DIR}"
 
-if [ -n "${CONFIG_FILE}" ]; then
+# -ef compares device and inode, so it needs no external command and is false
+# when either path is missing, where comparing two failed readlink calls would
+# match on empty output. The -L guard keeps a symlinked destination on the
+# install -T path below, which replaces the link with a root-owned regular file
+# rather than reaching through it to chmod the operator's own copy.
+if [ -n "${CONFIG_FILE}" ] && [ -f "${CONFIG_DIR}/config.toml" ] &&
+    [ ! -L "${CONFIG_DIR}/config.toml" ] &&
+    [ "${CONFIG_FILE}" -ef "${CONFIG_DIR}/config.toml" ]; then
+    # Copying a file onto itself fails, so re-apply the permissions only. This is
+    # the upgrade-in-place case: --config pointing at the live config.
+    chmod 440 "${CONFIG_DIR}/config.toml"
+    chown "root:${PROVIDER_GROUP}" "${CONFIG_DIR}/config.toml"
+    echo "Using config already at ${CONFIG_DIR}/config.toml"
+elif [ -n "${CONFIG_FILE}" ]; then
     install -T -m 440 -o "root" -g "${PROVIDER_GROUP}" "${CONFIG_FILE}" "${CONFIG_DIR}/config.toml"
     echo "Config installed from ${CONFIG_FILE}"
 elif [ -f "${CONFIG_DIR}/config.toml" ]; then
@@ -146,12 +222,64 @@ systemctl enable "${SM_SERVICE}" > /dev/null
 systemctl enable "${ACM_SERVICE}" > /dev/null
 
 if [ "${SKIP_START}" = false ]; then
+    # start, not restart, for the token unit: it is a oneshot whose ExecStop
+    # deletes the token file and whose ExecStart mints a new one, so restarting
+    # it would rotate the live SSRF token and 403 every client holding the old
+    # value. It does not run the provider binary, so it needs no restart.
     systemctl start "${TOKEN_SCRIPT}"
-    systemctl start "${SM_SERVICE}"
-    systemctl start "${ACM_SERVICE}"
+    # restart for the provider units: on an upgrade they are already active, so
+    # start would return success while the old binary keeps serving.
+    systemctl restart "${SM_SERVICE}"
+    systemctl restart "${ACM_SERVICE}"
+
     echo "Started services"
+
+    # Both units are Type=simple, so the start job finishes at fork and restart
+    # returns 0 even when the replacement exits straight away. A capability that
+    # is disabled in the config exits cleanly and leaves its unit inactive, which
+    # is fine; one that crashes lands in failed, or in auto-restart when the unit
+    # sets RestartSec, where two starts per StartLimitIntervalSec never reach the
+    # burst limit and the loop runs forever.
+    #
+    # Sampled once a second rather than once after a delay: a unit with
+    # RestartSec=5s reads active for most of its cycle, so any single sample can
+    # land in the healthy part of a crash loop. --value would read the properties
+    # more directly but needs systemd 230, and Amazon Linux 2 ships 219.
+    #
+    # Skipped when systemd is not running, as in an image build or a package
+    # scriptlet in a chroot, where no service can become healthy.
+    UNHEALTHY=""
+    if [ -d /run/systemd/system ]; then
+        SAMPLE=0
+        # Both units per second, so the window is 8 seconds in total rather than
+        # per unit.
+        while [ -z "${UNHEALTHY}" ] && [ "${SAMPLE}" -lt 8 ]; do
+            for unit in "${SM_SERVICE}" "${ACM_SERVICE}"; do
+                STATE=$(systemctl show -p ActiveState "${unit}")
+                STATE=${STATE#ActiveState=}
+                SUBSTATE=$(systemctl show -p SubState "${unit}")
+                SUBSTATE=${SUBSTATE#SubState=}
+                if [ "${STATE}" = failed ] || [ "${SUBSTATE}" = auto-restart ]; then
+                    UNHEALTHY="${unit}"
+                    echo "WARNING: ${unit} is ${STATE} (${SUBSTATE}) after restart" >&2
+                    systemctl status --no-pager --lines=20 "${unit}" >&2 || true
+                    break
+                fi
+            done
+            SAMPLE=$((SAMPLE + 1))
+            [ -n "${UNHEALTHY}" ] || sleep 1
+        done
+    fi
 else
     echo "Services enabled, start skipped (--no-start)"
 fi
 
 echo "Installation complete."
+
+# Exit 3, not 1, so the two failure modes stay apart: 1 means the install
+# aborted and the host was left alone, 3 means everything is installed but a
+# service is not running.
+if [ -n "${UNHEALTHY:-}" ]; then
+    echo "${UNHEALTHY} is installed but not healthy: fix the cause and run 'systemctl restart ${UNHEALTHY}'" >&2
+    exit 3
+fi

--- a/aws_workload_credentials_provider_common/configuration/install.ps1
+++ b/aws_workload_credentials_provider_common/configuration/install.ps1
@@ -160,6 +160,9 @@ Copy-Item -Path $providerBinary -Destination "$BIN_DIR\$PROVIDER_EXE" -Force
 Copy-Item -Path (Join-Path $SCRIPT_DIR "aws-workload-credentials-provider-token.ps1") -Destination "$BIN_DIR\aws-workload-credentials-provider-token.ps1" -Force
 Copy-Item -Path (Join-Path $SCRIPT_DIR "common.ps1") -Destination "$BIN_DIR\common.ps1" -Force
 Copy-Item -Path (Join-Path $SCRIPT_DIR "acmReloadConfig.ps1") -Destination "$BIN_DIR\acmReloadConfig.ps1" -Force
+# Staged so the host can be cleaned up later: a bootstrap install deletes the
+# downloaded bundle, which would otherwise be the only copy.
+Copy-Item -Path (Join-Path $SCRIPT_DIR "uninstall.ps1") -Destination "$BIN_DIR\uninstall.ps1" -Force
 Write-Host "  Installed $BIN_DIR\$PROVIDER_EXE"
 
 Write-Step "Register Windows Services"
@@ -192,7 +195,7 @@ if ($secretsManagerEnabled) {
 
     # Create the token file with locked-down ACLs. The seed token service
     # (running as SYSTEM) writes the value at boot. The ASM service account
-    # gets read-only access — only SYSTEM can write the token.
+    # gets read-only access; only SYSTEM can write the token.
     New-Item -ItemType File -Path $SSRF_TOKEN_FILE -Force | Out-Null
 
     icacls $SSRF_TOKEN_FILE /inheritance:r /Q | Out-Null

--- a/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
+++ b/aws_workload_credentials_provider_common/configuration/setup-permissions.sh
@@ -4,6 +4,8 @@
 # Sets up user, group, and directory permissions.
 #
 
+set -e
+
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 

--- a/aws_workload_credentials_provider_common/configuration/uninstall.ps1
+++ b/aws_workload_credentials_provider_common/configuration/uninstall.ps1
@@ -98,6 +98,10 @@ if (Test-Path $SSRF_TOKEN_FILE) {
 Write-Step "Remove install directory"
 
 if (Test-Path $INSTALL_DIR) {
+    # Windows won't delete a directory that is a process's current directory, and
+    # this script is installed inside the one being removed, so running it from
+    # there would delete the files and then fail on the directory itself.
+    Set-Location $env:SystemRoot
     Remove-Item -Path $INSTALL_DIR -Recurse -Force
     Write-Host "  Removed $INSTALL_DIR"
 } else {


### PR DESCRIPTION
## Description

Fixes to the provider install scripts, split out of the quick install PRs (#271, #277) so those can ship independently. Everything here lands in `aws_workload_credentials_provider_common/configuration/`, which the bootstrap installers take from the `v<version>` tag, so none of it takes effect until the next tagged release.

**Base branch is `feat/one-line-installer-windows`, so this sits on top of #271 and #277.**

**Stack**, bottom to top:
1. #271 Linux quick install (`install.sh`)
2. #277 Windows quick install (`install.ps1`)
3. #280 install script fixes (`configuration/`)

### Why is this change being made?

- The config is validated only after it has been copied and the units installed, so a rejected config leaves a half-configured host.
- `systemctl start` no-ops on an active unit, so an in-place upgrade leaves the old binary serving and still reports success.
- A relative `--config` is resolved after the script `cd`s, so it can resolve against the wrong directory.
- `--config` pointing at the live config aborts, because `install -T` cannot copy a file onto itself.
- `uninstall` and `common.sh` are not staged on the host, so a bootstrap install has no copy left to clean up with.
- On Windows, `uninstall.ps1` removes the directory it runs from, and is not staged at all.

### What is changing?

- **`configuration/install`**: pre-flight checks for the binary and the config before anything is created; the source directory is probed for exec capability, so a noexec or read-only staging directory is reported rather than mistaken for a broken binary; a relative `--config` is resolved before the `cd`; `--config` may point at the live config; `uninstall` and `common.sh` are staged into `${PROVIDER_DIR}/bin`; the provider units are restarted rather than started, with a health check afterwards; `set -e` is set in the body as well as the shebang.
- **`configuration/setup-permissions.sh`**: `set -e`.
- **`configuration/install.ps1`**: stages `uninstall.ps1` into `$BIN_DIR`.
- **`configuration/uninstall.ps1`**: moves out of `$INSTALL_DIR` before removing it, since Windows will not delete a process's current directory.

The token unit stays on `start`, because restarting it rotates the live SSRF token and 403s every client holding the old one.

### Related Links
- **Issue #, if available**: n/a
- Split out of #271 and #277, and stacked on both.

---

## Testing

### How was this tested?

Amazon Linux 2023 systemd containers on a dev box, driven through the bootstrap installer from #271 with this branch's configuration served at the `v3.1.1` tag path, against the live artifact host, live Secrets Manager and live ACM.

### When testing locally, provide testing artifact(s):

| area | result |
| --- | --- |
| install | exits 0; binary `755` reporting `3.1.1`; config `440 root:awscreds`; token file `640 aws-wcp-token`; units enabled and active |
| upgrade in place | SSRF token survives while the SM process is replaced (`MainPID` 218 to 401); staged `uninstall` exits 0 and removes the provider directory |
| exec probe | exec-capable directory runs the checks; mode `644` binary, noexec mount and read-only mount each skip them with a distinct message; a wrong-architecture binary in an exec-capable directory aborts |
| config comparison | `--config` at the live config re-applies permissions only; a symlinked destination is replaced by a root-owned regular file and the operator's copy is left at `644 root:root`; with `readlink` removed from the image a distinct `--config` is still installed |
| config pre-flight | a config the binary rejects, and a certificate path whose parent directory is missing, both abort with nothing installed |
| health check | polled once a second for 8 seconds, both units per pass. Healthy SM-only install exits 0 in 9.6s total; an SM process that exits 1 immediately and an ACM process that exits after 0.8s with `RestartSec=5s`, the shape a single sample missed, are both caught and exit 3. Skipped when `/run/systemd/system` is absent, as in an image build |
| ACM, live export | certificate, chain and key written `0644/0644/0600` as `aws-wcp:awscreds`; CN matches the ACM domain; key matches the certificate; chain parses; `cert-paths.conf` lists the cert directory; sudoers allows only the configured refresh command, which ran; `acm reload` exits 0 |
| static | shellcheck clean; all `.ps1` files parse clean and PSScriptAnalyzer reports nothing at Error or Warning |

### Not covered

- The Windows changes have no coverage on a real host: `-Version 3.1.1` runs v3.1.1's copy of these scripts, so the staged `uninstall.ps1` and its `Set-Location` need a build that includes them.
- The health check reports an unhealthy service with exit 3, distinct from the exit 1 the config pre-flight uses when nothing was installed, so the two cannot be confused. `Installation complete.` is still printed, because the files are installed.

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [x] I have reviewed, tested and understand all changes
- [x] I have filled out the Description and Testing sections above
- [ ] Build and Unit tests are passing
  *If not, why:* no Rust changes; CI covers it. One macOS run failed in `tests::max_conn_test`, a pre-existing timing flake, and passed on re-run.
- [ ] Unit test coverage check is passing
  *If not, why:* no Rust changes.
- [ ] Integration tests pass locally
  *If not, why:* they cover resources this does not touch; the installer was exercised against live Secrets Manager instead.
- [ ] I have updated integration tests (if needed)
  *If not, why:* the installer path is not in that suite, and the harness needs privileged containers with systemd.
- [x] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
- [x] I have added explanatory comments for complex logic, new classes/methods and new tests
- [x] I have updated README/documentation (if needed)
- [x] I have clearly called out breaking changes (if any)
  *`configuration/install` now restarts the two provider services rather than only starting them, so an in-place upgrade briefly interrupts them. The token service is left alone so the SSRF token survives.*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.




