### PR TITLE
chore: update `install.ps1` PS exec policy error

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -79,7 +79,7 @@ if ($PSVersionTable.PSVersion.Major -lt 5) {
 # services have been registered, so it is checked before any of that happens.
 $policy = Get-ExecutionPolicy
 if ($policy -in @("Restricted", "AllSigned")) {
-    throw "PowerShell execution policy is $policy, which blocks the unsigned install scripts this downloads. Re-run as 'powershell.exe -ExecutionPolicy Bypass -File <script>', or set 'Set-ExecutionPolicy -Scope Process Bypass' first."
+    throw "PowerShell execution policy is $policy, which blocks the unsigned install scripts this downloads."
 }
 
 $current = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()


### PR DESCRIPTION
## Description

### Why is this change being made?

1. Update the error message in `install.ps1` for the case where the PowerShell execution policy blocks the script.


### What is changing?

1. `install.ps1`


### Related Links
- **Issue #, if available**: N/A

---

## Testing

### How was this tested?

1. N/A

### When testing locally, provide testing artifact(s):

1. N/A

---

## Reviewee Checklist

**Update the checklist after submitting the PR**

- [ ] I have reviewed, tested and understand all changes
  *If not, why:*
- [ ] I have filled out the Description and Testing sections above
  *If not, why:*
- [ ] Build and Unit tests are passing
  *If not, why:*
- [ ] Unit test coverage check is passing
  *If not, why:*
- [ ] Integration tests pass locally
  *If not, why:*
- [ ] I have updated integration tests (if needed)
  *If not, why:*
- [ ] I have ensured no sensitive information is leaking (i.e., no logging of sensitive fields, or otherwise)
  *If not, why:*
- [ ] I have added explanatory comments for complex logic, new classes/methods and new tests
  *If not, why:*
- [ ] I have updated README/documentation (if needed)
  *If not, why:*
- [ ] I have clearly called out breaking changes (if any)
  *If not, why:*

---

## Reviewer Checklist

**All reviewers please ensure the following are true before reviewing:**

- Reviewee checklist has been accurately filled out
- Code changes align with stated purpose in description
- Test coverage adequately validates the changes

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
